### PR TITLE
make_column_dropper

### DIFF
--- a/foundry/preprocessing/__init__.py
+++ b/foundry/preprocessing/__init__.py
@@ -1,2 +1,8 @@
-from .sklearn import DataFrameTransformer, InteractionFeatures, as_transformer
+from .sklearn import (
+    DataFrameTransformer,
+    InteractionFeatures,
+    as_transformer,
+    identity,
+    make_column_dropper
+)
 from .dates import FourierFeatures

--- a/foundry/preprocessing/sklearn.py
+++ b/foundry/preprocessing/sklearn.py
@@ -157,7 +157,10 @@ def as_transformer(x: TransformerLike) -> TransformerMixin:
         raise TypeError(f"{type(x).__name__} does not have a `transform()` method.")
 
 
-def make_column_dropper(names: Optional[Union[str, Iterable[str]]]=None, pattern: Optional[str]=None):
+def make_column_dropper(
+    names: Optional[Union[str, Iterable[str]]]=None,
+    pattern: Optional[str]=None
+):
     """
     Returns a DataFrameTranformer (i.e. a ColumnTransformer) that drops a subset of features.
 

--- a/foundry/preprocessing/sklearn.py
+++ b/foundry/preprocessing/sklearn.py
@@ -157,7 +157,10 @@ def as_transformer(x: TransformerLike) -> TransformerMixin:
         raise TypeError(f"{type(x).__name__} does not have a `transform()` method.")
 
 
-def make_column_dropper(names: Optional[Union[str, Iterable[str]]]=None, pattern: Optional[str]=None):
+def make_column_dropper(
+    names: Optional[Union[str, Iterable[str]]]=None,
+    pattern: Optional[str]=None
+):
     """
     Returns a DataFrameTranformer (i.e. a ColumnTransformer) that drops a subset of features.
 
@@ -191,3 +194,27 @@ def make_column_dropper(names: Optional[Union[str, Iterable[str]]]=None, pattern
             ],
             **kwargs
         )
+
+
+class make_column_dropper_2:
+    def __init__(
+        self,
+        names: Optional[Union[str, Iterable[str]]]=None,
+        pattern: Optional[str]=None
+    ):
+        if names is not None and pattern is not None:
+            raise ValueError("Both names and pattern defined for drop_transformer. Only one may be defined.")
+
+        self.names = [names] if isinstance(names, str) else names
+        self.pattern = pattern
+
+    def __call__(
+        self, df: pd.DataFrame,
+    ):
+        if self.names is None and self.pattern is None:
+            return df
+        elif self.pattern is not None:
+            columns_to_drop: Iterable[str] = df.filter(regex=self.pattern).columns
+            return df.drop(columns=columns_to_drop)
+        else:
+            return df.drop(columns=self.names)

--- a/foundry/preprocessing/sklearn.py
+++ b/foundry/preprocessing/sklearn.py
@@ -157,10 +157,7 @@ def as_transformer(x: TransformerLike) -> TransformerMixin:
         raise TypeError(f"{type(x).__name__} does not have a `transform()` method.")
 
 
-def make_column_dropper(
-    names: Optional[Union[str, Iterable[str]]]=None,
-    pattern: Optional[str]=None
-):
+def make_column_dropper(names: Optional[Union[str, Iterable[str]]]=None, pattern: Optional[str]=None):
     """
     Returns a DataFrameTranformer (i.e. a ColumnTransformer) that drops a subset of features.
 
@@ -194,27 +191,3 @@ def make_column_dropper(
             ],
             **kwargs
         )
-
-
-class make_column_dropper_2:
-    def __init__(
-        self,
-        names: Optional[Union[str, Iterable[str]]]=None,
-        pattern: Optional[str]=None
-    ):
-        if names is not None and pattern is not None:
-            raise ValueError("Both names and pattern defined for drop_transformer. Only one may be defined.")
-
-        self.names = [names] if isinstance(names, str) else names
-        self.pattern = pattern
-
-    def __call__(
-        self, df: pd.DataFrame,
-    ):
-        if self.names is None and self.pattern is None:
-            return df
-        elif self.pattern is not None:
-            columns_to_drop: Iterable[str] = df.filter(regex=self.pattern).columns
-            return df.drop(columns=columns_to_drop)
-        else:
-            return df.drop(columns=self.names)

--- a/foundry/preprocessing/sklearn.py
+++ b/foundry/preprocessing/sklearn.py
@@ -1,12 +1,12 @@
 import itertools
-from typing import Callable, Iterable, Sequence, Tuple, Union
+from typing import Callable, Iterable, Optional, Sequence, Tuple, Union
 from warnings import warn
 
 import numpy as np
 import pandas as pd
 from scipy import sparse
 from sklearn.base import BaseEstimator, TransformerMixin
-from sklearn.compose import ColumnTransformer
+from sklearn.compose import ColumnTransformer, make_column_selector
 from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import FunctionTransformer as FunctionTransformerBase
 
@@ -155,3 +155,39 @@ def as_transformer(x: TransformerLike) -> TransformerMixin:
         return FunctionTransformer(x)
     else:
         raise TypeError(f"{type(x).__name__} does not have a `transform()` method.")
+
+
+def make_column_dropper(names: Optional[Union[str, Iterable[str]]]=None, pattern: Optional[str]=None):
+    """
+    Returns a DataFrameTranformer (i.e. a ColumnTransformer) that drops a subset of features.
+
+    Useful when you want certain downstream paths of the sklearn pipeline to use different features than each other.
+
+    names: the name or names of features to drop
+    regex: the pattern to match for features to drop
+    """
+    kwargs = {
+        "remainder": "passthrough", # we specify which columns to drop, the rest stay.
+        "verbose_feature_names_out": False, # don't add the "remainder__" prefix to the undropped columns
+    }
+    if names is None and pattern is None:
+        return DataFrameTransformer(transformers = [], **kwargs)
+    if names and pattern:
+        raise ValueError("Both names and regex defined for drop_transformer. Only one may be defined.")
+
+    # regex part
+    if pattern is not None:
+        return DataFrameTransformer(
+            transformers = [
+                ("drop", "drop", make_column_selector(pattern))
+            ],
+            **kwargs
+        )
+    # names part
+    else:
+        return DataFrameTransformer(
+            transformers=[
+                ("drop", "drop", names)
+            ],
+            **kwargs
+        )

--- a/tests/preprocessing/test_sklearn.py
+++ b/tests/preprocessing/test_sklearn.py
@@ -1,0 +1,60 @@
+from typing import Callable
+import pandas as pd
+import numpy as np
+import pytest
+from unittest.mock import patch
+from pandas.testing import assert_series_equal, assert_frame_equal
+from sklearn.pipeline import make_pipeline
+
+from foundry.preprocessing import make_column_dropper
+
+@pytest.fixture()
+def small_dataframe():
+    return pd.DataFrame({
+        "A": [0., 1., 2., 3.],
+        "B": [0.5, -0.5, 0.5, -0.5],
+        "C": [-1., -2., -3., -4.],
+    })
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected",
+    [
+        (
+            dict(),
+            pd.DataFrame({"A": [0., 1., 2., 3.,], "B": [0.5, -0.5, 0.5, -0.5], "C": [-1., -2., -3., -4.,]})
+        ),
+        (
+            {"names": "A"},
+            pd.DataFrame({"B": [0.5, -0.5, 0.5, -0.5], "C": [-1., -2., -3., -4.]})
+        ),
+        (
+            {"names": ["A", "B"]},
+            pd.DataFrame({"C": [-1., -2., -3., -4.,]})
+        ),
+        (
+            {"pattern": "[AB]"},
+            pd.DataFrame({"C": [-1., -2., -3., -4.,]})
+        ),
+        pytest.param(
+            {"names": "A", "pattern": ".*"},
+            None,
+            marks=pytest.mark.xfail(raises=ValueError)
+        ),
+    ],
+    ids=[
+        "no_drop",
+        "drop_by_name",
+        "drop_by_names",
+        "drop_by_regex",
+        "err_too_many",
+    ]
+)
+def test_make_column_dropper(small_dataframe, kwargs, expected):
+    my_pipeline = make_pipeline(
+        make_column_dropper(**kwargs)
+    )
+
+    test = my_pipeline.fit(small_dataframe).transform(small_dataframe)
+
+    assert_frame_equal(expected, test)


### PR DESCRIPTION
Adds an easy way to make a `DataFrameTransformer` that drops features when needed. 

For example, suppose that the previous steps of a pipeline returns a number of features, `["scaled__A", "scaled__B",  "centered__A", "centered__B"]`, and we only want the first three features for the model. Then we can add another step to the pipeline, `make_pipeline(..., make_column_dropper(names="centered__B"), LinearRegression())`

Or we can pass a regex, which might be useful if there was a feature like `"centered__inverted__B"`, by using `make_column_dropper(pattern="centered__.*__B")`