### PR TITLE
make_column_dropper -> make_drop_transformer

### DIFF
--- a/foundry/preprocessing/__init__.py
+++ b/foundry/preprocessing/__init__.py
@@ -3,6 +3,7 @@ from .sklearn import (
     InteractionFeatures,
     as_transformer,
     identity,
-    make_drop_transformer
+    make_column_selector,
+    make_drop_transformer,
 )
 from .dates import FourierFeatures

--- a/foundry/preprocessing/__init__.py
+++ b/foundry/preprocessing/__init__.py
@@ -3,6 +3,6 @@ from .sklearn import (
     InteractionFeatures,
     as_transformer,
     identity,
-    make_column_dropper
+    make_drop_transformer
 )
 from .dates import FourierFeatures

--- a/foundry/preprocessing/sklearn.py
+++ b/foundry/preprocessing/sklearn.py
@@ -6,7 +6,8 @@ import numpy as np
 import pandas as pd
 from scipy import sparse
 from sklearn.base import BaseEstimator, TransformerMixin
-from sklearn.compose import ColumnTransformer, make_column_selector
+from sklearn.compose import ColumnTransformer
+from sklearn.compose import make_column_selector as make_column_selector_sklearn
 from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import FunctionTransformer as FunctionTransformerBase
 
@@ -156,7 +157,9 @@ def as_transformer(x: TransformerLike) -> TransformerMixin:
     else:
         raise TypeError(f"{type(x).__name__} does not have a `transform()` method.")
 
-
+class make_column_selector(make_column_selector_sklearn):
+    def __repr__(self):
+        return f"make_column_selector(pattern={self.pattern}, dtype_include={self.dtype_include}, dtype_exclude={self.dtype_exclude})"
 
 def make_column_dropper(*args, **kwargs):
     warn("make_column_dropper is deprecated, use make_drop_transformer")

--- a/foundry/preprocessing/sklearn.py
+++ b/foundry/preprocessing/sklearn.py
@@ -161,10 +161,6 @@ class make_column_selector(make_column_selector_sklearn):
     def __repr__(self):
         return f"make_column_selector(pattern={self.pattern}, dtype_include={self.dtype_include}, dtype_exclude={self.dtype_exclude})"
 
-def make_column_dropper(*args, **kwargs):
-    warn("make_column_dropper is deprecated, use make_drop_transformer")
-    return make_drop_transformer(*args, **kwargs)
-
 def make_drop_transformer(
     names: Optional[Union[str, Iterable[str]]]=None,
     pattern: Optional[str]=None

--- a/foundry/preprocessing/sklearn.py
+++ b/foundry/preprocessing/sklearn.py
@@ -157,7 +157,12 @@ def as_transformer(x: TransformerLike) -> TransformerMixin:
         raise TypeError(f"{type(x).__name__} does not have a `transform()` method.")
 
 
-def make_column_dropper(
+
+def make_column_dropper(*args, **kwargs):
+    warn("make_column_dropper is deprecated, use make_drop_transformer")
+    return make_drop_transformer(*args, **kwargs)
+
+def make_drop_transformer(
     names: Optional[Union[str, Iterable[str]]]=None,
     pattern: Optional[str]=None
 ):

--- a/tests/preprocessing/test_sklearn.py
+++ b/tests/preprocessing/test_sklearn.py
@@ -3,7 +3,7 @@ import pytest
 from pandas.testing import assert_frame_equal
 from sklearn.pipeline import make_pipeline
 
-from foundry.preprocessing import make_drop_transformer
+from foundry.preprocessing import make_drop_transformer, make_column_selector
 
 
 @pytest.fixture()
@@ -56,3 +56,15 @@ def test_make_drop_transformer(small_dataframe, kwargs, expected):
     test = my_pipeline.fit(small_dataframe).transform(small_dataframe)
 
     assert_frame_equal(expected, test)
+
+
+def test_make_column_selector():
+    small_dataframe = pd.DataFrame({
+        "A": [0., 1., 2., 3., ],
+        "B": [0.5, -0.5, 0.5, -0.5],
+        "C": [-1., -2., -3., -4., ]
+    })
+    column_selector = make_column_selector("[AB]")
+
+    assert column_selector(small_dataframe) == ["A", "B"]
+    assert "[AB]" in repr(column_selector)

--- a/tests/preprocessing/test_sklearn.py
+++ b/tests/preprocessing/test_sklearn.py
@@ -3,7 +3,7 @@ import pytest
 from pandas.testing import assert_frame_equal
 from sklearn.pipeline import make_pipeline
 
-from foundry.preprocessing import make_column_dropper
+from foundry.preprocessing import make_drop_transformer
 
 
 @pytest.fixture()
@@ -48,9 +48,9 @@ def small_dataframe():
         "err_too_many",
     ]
 )
-def test_make_column_dropper(small_dataframe, kwargs, expected):
+def test_make_drop_transformer(small_dataframe, kwargs, expected):
     my_pipeline = make_pipeline(
-        make_column_dropper(**kwargs)
+        make_drop_transformer(**kwargs)
     )
 
     test = my_pipeline.fit(small_dataframe).transform(small_dataframe)


### PR DESCRIPTION
2 things here:
1. I changed my mind on the previous PR (#6). `make_column_dropper` is a terrible name when it behaves differently to `make_column_selector`. 
2. Adding a `__repr__` for `make_column_selector`. 