### PR TITLE
Feature/interaction get feature names out

### DIFF
--- a/foundry/glm/glm.py
+++ b/foundry/glm/glm.py
@@ -54,6 +54,11 @@ class SigmoidTransformForClassification(transforms.SigmoidTransform):
         return y_dim - 1
 
 
+class SigmoidTransformForClassification(transforms.SigmoidTransform):
+    def get_param_dim(self, y_dim: int) -> int:
+        return y_dim - 1
+
+
 class Glm(BaseEstimator):
     """
     :param family: A family name; you can see available names with ``Glm.family_names``. (Advanced: you can also pass

--- a/foundry/preprocessing/sklearn.py
+++ b/foundry/preprocessing/sklearn.py
@@ -117,7 +117,7 @@ class InteractionFeatures(TransformerMixin, BaseEstimator):
             if len(interaction) < 2:
                 continue
             new_colname = self.sep.join(interaction)
-            if new_colname in X.columns and new_colname not in available_cols:
+            if new_colname in X.columns:
                 warn(f"{new_colname} is duplicated.")
 
             new_cols[new_colname] = None

--- a/tests/glm/test_glm.py
+++ b/tests/glm/test_glm.py
@@ -51,6 +51,17 @@ def test_classification_integration(family: str):
     glm.fit(X=X, y=y, verbose=False)
 
 
+@pytest.mark.parametrize(
+    argnames=['family'],
+    argvalues=[('categorical',), ('bernoulli',)]
+)
+def test_classification_integration(family: str):
+    y = pd.Series([0] * 3 + [1] * 2, name='cat').to_frame()
+    glm = Glm(family=family)
+    X = pd.DataFrame(index=y.index)
+    glm.fit(X=X, y=y, verbose=False)
+
+
 class _FakeDist:
     arg_constraints = {
         'param1': constraints.real,

--- a/tests/preprocessing/test_sklearn.py
+++ b/tests/preprocessing/test_sklearn.py
@@ -134,7 +134,7 @@ class TestInteractionFeatures:
             ),
             pytest.param(
                 [('col1', 'col1')],
-                [('col1', 'col1')],
+                [],
                 id='paired-feature',
             ),
             pytest.param(

--- a/tests/preprocessing/test_sklearn.py
+++ b/tests/preprocessing/test_sklearn.py
@@ -133,6 +133,11 @@ class TestInteractionFeatures:
                 id='with_callable'
             ),
             pytest.param(
+                [('col1', 'col1')],
+                [('col1', 'col1')],
+                id='paired-feature',
+            ),
+            pytest.param(
                 [('col1', make_column_selector(pattern='unmatched'))],
                 RuntimeError,
                 id='callable_returns_nothing',


### PR DESCRIPTION
I wanted to add `get_feature_names_out()` to `InteractionFeatures` to support the work in #16 

Also I squashed a `"col1:col2 already exists in X"` bug in the `transform` logic. 

all tests passing. 